### PR TITLE
Corrected typo in file api-deployment.yaml

### DIFF
--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      label:
+      labels:
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:


### PR DESCRIPTION
I wrote "label" instead of "labels" by mistake. Due to this typo, the deployment in okteto was not possible