### PR TITLE
Corrected errors in deployment configuration

### DIFF
--- a/chart/templates/api-deployment.yaml
+++ b/chart/templates/api-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      label:
+      labels:
         app.kubernetes.io/name: api
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ app.get("/", (req, res) => {
     res.send("<html><body><h1>My server</h1></body></html>");
 });
 
-app.get("/healthz", (req, res) => {
+app.get(BASE_API_PATH + "/healthz", (req, res) => {
     res.sendStatus(200);
 });
 


### PR DESCRIPTION
The /healthz endpoint did not contain the complete path (i.e., "/healthz" instead of "/api/v1/healthz"). I also corrected a typo in the api-deployment.yaml file (I wrote "label" instead of "labels"